### PR TITLE
refactor: 🏄🏽 simplify semver logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "insta",
  "log",
  "nom",
+ "semver",
  "serde",
  "toml",
  "trycmd",
@@ -1196,6 +1197,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ env_logger = "0.11.6"
 git2 = "0.20.0"
 log = "0.4.22"
 nom = "7.1.3"
+semver = "1.0.24"
 serde = { version = "1.0.217", features = ["derive"] }
 toml = "0.8.19"
 

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ coverage:
         LLVM_PROFILE_FILE="rust_crate_diffs-%p-%m.profraw" cargo test
     grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing \
         -o ./target/debug/coverage/
-    open ./target/debug/coverage
+    open --reveal ./target/debug/coverage
     sed -i '' "s|href=\"https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css\"|href=\"file://`pwd`/.cache/bulma.min.css\"|g" ./target/debug/coverage/**/*.html
     mkdir -p .cache
     curl --time-cond .cache/bulma.min.css -C - -Lo .cache/bulma.min.css \


### PR DESCRIPTION
# Description

Add the semver Rust crate as a dependency, to simplify logic in the semver
module. This should facilitate extending support for other semver version
specifications not yet implemented.

## Type of change

- [x] Refactor

# How Has This Been Tested?

- [x] cargo test run with all tests passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
