### PR TITLE
ci  update ci config

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
       - name: Install Linux Dependencies
         run: sudo apt-get update
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
+      - uses: dtolnay/rust-toolchain@1ff72ee08e3cb84d84adba594e0a297990fc1ed3
       - name: Run tests
         run: cargo test
   fmt:
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
+      - uses: dtolnay/rust-toolchain@1ff72ee08e3cb84d84adba594e0a297990fc1ed3
         with:
           components: rustfmt
       - name: Enforce formatting
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -57,12 +57,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
+      - uses: dtolnay/rust-toolchain@1ff72ee08e3cb84d84adba594e0a297990fc1ed3
         with:
           components: clippy
       - name: Linting
@@ -78,7 +78,7 @@ jobs:
       - name: Install Linux Dependencies
         run: sudo apt-get update
       - name: Install ${{ matrix.msrv }}
-        uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
+        uses: dtolnay/rust-toolchain@1ff72ee08e3cb84d84adba594e0a297990fc1ed3
         with:
           toolchain: ${{ matrix.msrv }}
       - name: generate lockfile
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
@@ -98,7 +98,7 @@ jobs:
         run: sudo apt-get update
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
+      - uses: dtolnay/rust-toolchain@1ff72ee08e3cb84d84adba594e0a297990fc1ed3
         with:
           components: llvm-tools-preview
       - name: Install grcov
@@ -110,7 +110,7 @@ jobs:
       - name: Generate code coverage
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
+        uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
         with:
           files: ./target/debug/lcov
         env:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
@@ -19,7 +19,7 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
       - name: Run lychee
-        uses: lycheeverse/lychee-action@f81112d0d2814ded911bd23e3beaa9dda9093915 # v2.1.0
+        uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
         with:
           args: "--base . --cache --max-cache-age 1d --exclude-path \"deny.toml\" . \"**/*.toml\" \"**/*.rs\" \"**/*.yml\""
           fail: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.13'
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '>=1.18.0'
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
       # actions: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
@@ -58,13 +58,13 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@babb554ede22fd5605947329c4d04d8e7a0b8155 # v3.27.7
+        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
           disable-telemetry: true
       - name: Checkout Actions Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check spelling of entire workspace
-        uses: crate-ci/typos@2872c382bb9668d4baa5eade234dcbc0048ca2cf # v1.28.2
+        uses: crate-ci/typos@685eb3d55be2f85191e8c84acb9f44d7756f84ab # v1.29.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,37 @@
 repos:
-  - hooks:
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.1.1
+    hooks:
       - id: commitizen
         stages:
           - commit-msg
-    repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.1.0
-  - hooks:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
       - id: fmt
       - id: cargo-check
       - id: clippy
-    repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
-  - hooks:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.3
+    hooks:
       - id: gitleaks
-    repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
-  - hooks:
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.15.0
+    hooks:
       - id: yamlfmt
-    repo: https://github.com/google/yamlfmt
-    rev: v0.14.0
-  - hooks:
-      - args:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args:
           - --markdown-linebreak-ext=md
-        id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-      - exclude: .vscode
-        id: check-json
+      - id: check-json
+        exclude: .vscode
       - id: no-commit-to-branch
-    repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-  - hooks:
-      - args:
-          - --all-features
-          - check
-        id: cargo-deny
-    repo: https://github.com/EmbarkStudios/cargo-deny
-    rev: 0.16.3
+  - repo: https://github.com/EmbarkStudios/cargo-deny
+    rev: 0.16.4
+    hooks:
+      - id: cargo-deny
+        args: ["--all-features", "check"]

--- a/dprint.json
+++ b/dprint.json
@@ -1,16 +1,11 @@
 {
-  "json": {
-  },
-  "markdown": {
-  },
-  "toml": {
-  },
-  "excludes": [
-    "**/*-lock.json"
-  ],
+  "json": {},
+  "markdown": {},
+  "toml": {},
+  "excludes": ["**/*-lock.json"],
   "plugins": [
     "https://plugins.dprint.dev/json-0.19.4.wasm",
     "https://plugins.dprint.dev/markdown-0.17.8.wasm",
-    "https://plugins.dprint.dev/toml-0.6.3.wasm"
+    "https://plugins.dprint.dev/toml-0.6.4.wasm"
   ]
 }


### PR DESCRIPTION
# Description

Merge with rust-ci-config to update GitHub Actions, pre-commit and dprint
configuration.

- **build(deps): bump EmbarkStudios/cargo-deny-action from 1.5.15 to 1.6.2**
- **build(deps): bump actions/setup-python from 5.0.0 to 5.1.0**
- **build(deps): bump codecov/codecov-action from 4.1.0 to 4.3.0**
- **build(deps): bump actions/dependency-review-action from 4.1.3 to 4.2.5**
- **ci: 🦀 initial commit**
- **build(deps): bump actions/checkout from 4.1.1 to 4.1.2**
- **ci: 💫 update CI config**
- **build(deps): bump github/codeql-action from 3.24.8 to 3.24.10**
- **build(deps): bump github/codeql-action from 3.24.10 to 3.25.1**
- **ci: 🐝 update CI config**
- **build(deps): bump actions/upload-artifact from 4.3.1 to 4.3.2**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump actions/checkout from 4.1.2 to 4.1.3**
- **build(deps): bump github/codeql-action from 3.25.1 to 3.25.2**
- **build(deps): bump actions/upload-artifact from 4.3.2 to 4.3.3**
- **build(deps): bump EmbarkStudios/cargo-deny-action from 1.6.2 to 1.6.3**
- **build(deps): bump actions/checkout from 4.1.3 to 4.1.4**
- **build(deps): bump github/codeql-action from 3.25.2 to 3.25.3**
- **build(deps): bump step-security/harden-runner from 2.7.0 to 2.7.1**
- **build(deps): bump actions/dependency-review-action from 4.2.5 to 4.3.2**
- **ci: 🐝 update pre-commit config**
- **ci: 🐝 update CI config**
- **ci: 🐝 update CI config**
- **build(deps): bump codecov/codecov-action from 4.3.0 to 4.3.1**
- **build(deps): bump actions/setup-go from 5.0.0 to 5.0.1**
- **ci: 🐝 update CI config**
- **build(deps): bump actions/checkout from 4.1.4 to 4.1.5**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump github/codeql-action from 3.25.3 to 3.25.4**
- **build(deps): bump ossf/scorecard-action from 2.3.1 to 2.3.3**
- **build(deps): bump github/codeql-action from 3.25.4 to 3.25.5**
- **ci: 🐝 update CI config**
- **build(deps): bump codecov/codecov-action from 4.3.1 to 4.4.0**
- **build(deps): bump actions/checkout from 4.1.5 to 4.1.6**
- **ci: 🐝 update pre-commit config**
- **--- updated-dependencies: - dependency-name: codecov/codecov-action dependency-type: direct:production update-type: version-update:semver-patch ...**
- **--- updated-dependencies: - dependency-name: github/codeql-action dependency-type: direct:production update-type: version-update:semver-patch ...**
- **--- updated-dependencies: - dependency-name: step-security/harden-runner dependency-type: direct:production update-type: version-update:semver-minor ...**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump github/codeql-action from 3.25.6 to 3.25.7**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump github/codeql-action from 3.25.7 to 3.25.8**
- **build(deps): bump actions/dependency-review-action from 4.3.2 to 4.3.3**
- **build(deps): bump step-security/harden-runner from 2.8.0 to 2.8.1**
- **build(deps): bump actions/checkout from 4.1.6 to 4.1.7**
- **build(deps): bump github/codeql-action from 3.25.8 to 3.25.9**
- **build(deps): bump github/codeql-action from 3.25.9 to 3.25.10**
- **build(deps): bump codecov/codecov-action from 4.4.1 to 4.5.0**
- **build(deps): bump github/codeql-action from 3.25.10 to 3.25.11**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump actions/upload-artifact from 4.3.3 to 4.3.4**
- **build(deps): bump actions/setup-python from 5.1.0 to 5.1.1**
- **build(deps): bump actions/setup-go from 5.0.1 to 5.0.2**
- **build(deps): bump actions/dependency-review-action from 4.3.3 to 4.3.4**
- **build(deps): bump github/codeql-action from 3.25.11 to 3.25.12**
- **build(deps): bump step-security/harden-runner from 2.8.1 to 2.9.0**
- **ci: 🐝 update CI config**
- **build(deps): bump github/codeql-action from 3.25.12 to 3.25.13**
- **build(deps): bump github/codeql-action from 3.25.13 to 3.25.14**
- **build(deps): bump ossf/scorecard-action from 2.3.3 to 2.4.0**
- **build(deps): bump github/codeql-action from 3.25.14 to 3.25.15**
- **ci: 🐝 update CI config**
- **build(deps): bump actions/upload-artifact from 4.3.4 to 4.3.5**
- **build(deps): bump EmbarkStudios/cargo-deny-action from 1.6.3 to 2.0.0**
- **build(deps): bump step-security/harden-runner from 2.9.0 to 2.9.1**
- **build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.0 to 2.0.1**
- **build(deps): bump github/codeql-action from 3.25.15 to 3.26.0**
- **build(deps): bump actions/upload-artifact from 4.3.5 to 4.3.6**
- **build(deps): bump github/codeql-action from 3.26.0 to 3.26.1**
- **ci: 🐝 update CI config**
- **build(deps): bump github/codeql-action from 3.26.1 to 3.26.2**
- **build(deps): bump github/codeql-action from 3.26.2 to 3.26.3**
- **ci: 🐝 update dprint config**
- **build(deps): bump github/codeql-action from 3.26.3 to 3.26.4**
- **ci: 🐝 update dprint config**
- **build(deps): bump github/codeql-action from 3.26.4 to 3.26.5**
- **build(deps): bump actions/setup-python from 5.1.1 to 5.2.0**
- **build(deps): bump github/codeql-action from 3.26.5 to 3.26.6**
- **build(deps): bump actions/upload-artifact from 4.3.6 to 4.4.0**
- **ci: 🐝 update CI config**
- **build(deps): bump step-security/harden-runner from 2.9.1 to 2.10.1**
- **build(deps): bump github/codeql-action from 3.26.6 to 3.26.7**
- **ci: 🐝 update CI config**
- **build(deps): bump rustsec/audit-check from 1.4.1 to 2.0.0**
- **build(deps): bump github/codeql-action from 3.26.7 to 3.26.9**
- **build(deps): bump actions/checkout from 4.1.7 to 4.2.0**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump github/codeql-action from 3.26.9 to 3.26.10**
- **build(deps): bump codecov/codecov-action from 4.5.0 to 4.6.0**
- **build(deps): bump github/codeql-action from 3.26.10 to 3.26.11**
- **ci: 🐝 update CI config**
- **build(deps): bump actions/checkout from 4.2.0 to 4.2.1**
- **build(deps): bump actions/upload-artifact from 4.4.0 to 4.4.3**
- **build(deps): bump github/codeql-action from 3.26.11 to 3.26.13**
- **ci: 🐝 update CI config**
- **build(deps): bump actions/dependency-review-action from 4.3.4 to 4.3.5**
- **ci: 🐝 update dprint config**
- **build(deps): bump github/codeql-action from 3.26.13 to 3.27.0**
- **build(deps): bump actions/checkout from 4.2.1 to 4.2.2**
- **build(deps): bump actions/setup-go from 5.0.2 to 5.1.0**
- **build(deps): bump actions/setup-python from 5.2.0 to 5.3.0**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump actions/dependency-review-action from 4.3.5 to 4.4.0**
- **ci: 🐝 update CI config**
- **build(deps): bump github/codeql-action from 3.27.0 to 3.27.1**
- **ci: 🐝 update CI config**
- **ci: 🐝 update CI config**
- **ci: 🐝 update CI config**
- **build(deps): bump github/codeql-action from 3.27.1 to 3.27.3**
- **build(deps): bump codecov/codecov-action from 4.6.0 to 5.0.0**
- **build(deps): bump github/codeql-action from 3.27.3 to 3.27.4**
- **build(deps): bump codecov/codecov-action from 5.0.0 to 5.0.2**
- **ci: 🐝 update CI config**
- **build(deps): bump step-security/harden-runner from 2.10.1 to 2.10.2**
- **ci: 🐝 update PR template**
- **build(deps): bump codecov/codecov-action from 5.0.2 to 5.0.4**
- **build(deps): bump github/codeql-action from 3.27.4 to 3.27.5**
- **build(deps): bump codecov/codecov-action from 5.0.4 to 5.0.7**
- **build(deps): bump actions/dependency-review-action from 4.4.0 to 4.5.0**
- **build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.1 to 2.0.2**
- **ci: 🐝 update CI config**
- **build(deps): bump crate-ci/typos from 1.27.3 to 1.28.0**
- **ci: 🐝 update CI config**
- **build(deps): bump crate-ci/typos from 1.28.0 to 1.28.1**
- **build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.2 to 2.0.3**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump crate-ci/typos from 1.28.1 to 1.28.2**
- **build(deps): bump github/codeql-action from 3.27.5 to 3.27.6**
- **build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.3 to 2.0.4**
- **build(deps): bump actions/cache from 4.1.2 to 4.2.0**
- **build(deps): bump codecov/codecov-action from 5.0.7 to 5.1.1**
- **ci: 🐝 update CI config**
- **build(deps): bump actions/setup-go from 5.1.0 to 5.2.0**
- **build(deps): bump github/codeql-action from 3.27.6 to 3.27.7**
- **build(deps): bump github/codeql-action from 3.27.7 to 3.27.9**
- **build(deps): bump crate-ci/typos from 1.28.2 to 1.28.3**
- **build(deps): bump crate-ci/typos from 1.28.3 to 1.28.4**
- **build(deps): bump actions/upload-artifact from 4.4.3 to 4.5.0**
- **ci: 🐝 update CI config**
- **build(deps): bump codecov/codecov-action from 5.1.1 to 5.1.2**
- **ci: 🐝 update CI config**
- **Update dependabot.yml**
- **build(deps): bump crate-ci/typos from 1.28.4 to 1.29.4**
- **build(deps): bump github/codeql-action from 3.27.9 to 3.28.1**
- **build(deps): bump actions/setup-go from 5.2.0 to 5.3.0**
- **build(deps): bump lycheeverse/lychee-action from 2.1.0 to 2.2.0**
- **build(deps): bump actions/upload-artifact from 4.5.0 to 4.6.0**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump step-security/harden-runner from 2.10.2 to 2.10.4**
- **build(deps): bump github/codeql-action from 3.28.1 to 3.28.2**
- **build(deps): bump github/codeql-action from 3.28.2 to 3.28.3**
- **build(deps): bump codecov/codecov-action from 5.1.2 to 5.2.0**
- **build(deps): bump codecov/codecov-action from 5.2.0 to 5.3.0**
- **build(deps): bump github/codeql-action from 3.28.3 to 3.28.4**
- **build(deps): bump codecov/codecov-action from 5.3.0 to 5.3.1**
- **build(deps): bump actions/setup-python from 5.3.0 to 5.4.0**
- **ci: 🐝 update pre-commit config**
- **build(deps): bump github/codeql-action from 3.28.4 to 3.28.8**
- **ci: 🐝 update pre-commit config**

## Type of change

- [x] CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
