### PR TITLE
fix: 💫 add greater semver support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,7 @@ Please describe the tests that you ran to verify your changes. Provide
 instructions so we can reproduce. Please also list any relevant details for your
 test configuration
 
-- [ ] Test A
-- [ ] Test B
+- [ ] cargo test run with all tests passing
 
 **Test Configuration**:
 

--- a/src/domain/semver/mod.rs
+++ b/src/domain/semver/mod.rs
@@ -226,6 +226,55 @@ impl Version {
         }
     }
 
+    fn exact_range(major: u64, minor: Option<u64>, patch: Option<u64>) -> Range<semver::Version> {
+        if let Some(minor_version) = minor {
+            if let Some(patch_version) = patch {
+                // =I.J.K
+                Range {
+                    start: semver::Version::new(major, minor_version, patch_version),
+                    end: Self::version_with_bumped_patch(major, minor_version, patch_version),
+                }
+            } else {
+                // =I.J
+                Range {
+                    start: semver::Version::new(major, minor_version, 0),
+                    end: Self::version_with_bumped_minor(major, minor_version),
+                }
+            }
+        } else {
+            // =I
+            Range {
+                start: semver::Version::new(major, 0, 0),
+                end: Self::version_with_bumped_major(major),
+            }
+        }
+    }
+
+    fn greater_range(major: u64, minor: Option<u64>, patch: Option<u64>) -> Range<semver::Version> {
+        let end = semver::Version::new(u64::MAX, u64::MAX, u64::MAX);
+        if let Some(minor_version) = minor {
+            if let Some(patch_version) = patch {
+                // >I.J.K
+                Range {
+                    start: Self::version_with_bumped_patch(major, minor_version, patch_version),
+                    end,
+                }
+            } else {
+                // >I.J
+                Range {
+                    start: Self::version_with_bumped_minor(major, minor_version),
+                    end,
+                }
+            }
+        } else {
+            // >I
+            Range {
+                start: Self::version_with_bumped_major(major),
+                end,
+            }
+        }
+    }
+
     fn range(&self) -> Range<semver::Version> {
         let first_comparator = self.req.comparators.first().unwrap();
 
@@ -238,34 +287,9 @@ impl Version {
         } = first_comparator;
         match op {
             Op::Caret => Self::caret_range(*major, *minor, *patch),
-            Op::Exact => {
-                if let Some(minor_version) = minor {
-                    if let Some(patch_version) = patch {
-                        // =I.J.K
-                        Range {
-                            start: semver::Version::new(*major, *minor_version, *patch_version),
-                            end: Self::version_with_bumped_patch(
-                                *major,
-                                *minor_version,
-                                *patch_version,
-                            ),
-                        }
-                    } else {
-                        // =I.J
-                        Range {
-                            start: semver::Version::new(*major, *minor_version, 0),
-                            end: Self::version_with_bumped_minor(*major, *minor_version),
-                        }
-                    }
-                } else {
-                    // =I
-                    Range {
-                        start: semver::Version::new(*major, 0, 0),
-                        end: Self::version_with_bumped_major(*major),
-                    }
-                }
-            }
-            _ => todo!("Ranges only implemented for tilde and exact requirements so far."),
+            Op::Exact => Self::exact_range(*major, *minor, *patch),
+            Op::Greater => Self::greater_range(*major, *minor, *patch),
+            _ => todo!("Ranges only implemented for tilde, exact and greater requirements so far."),
         }
     }
 
@@ -323,8 +347,8 @@ impl Version {
         }
         let Comparator { op, .. } = req.comparators.first().expect("Index should be valid");
         match op {
-            Op::Caret | Op::Exact => Ok(()),
-            Op::GreaterEq | Op::Greater | Op::Less | Op::LessEq => Err(String::from(
+            Op::Caret | Op::Exact | Op::Greater => Ok(()),
+            Op::GreaterEq | Op::Less | Op::LessEq => Err(String::from(
                 "Range version requirement comparison is not yet implemented",
             )),
             Op::Tilde => Err(String::from(

--- a/src/domain/semver/tests.rs
+++ b/src/domain/semver/tests.rs
@@ -191,6 +191,76 @@ fn semver_version_applies_partial_order_as_expected_for_exact_requirements() {
 }
 
 #[test]
+fn semver_version_applies_partial_order_as_expected_for_greater_requirements() {
+    // assert
+    assert!(SemverVersion::new(">1.2.3").unwrap() < SemverVersion::new(">1.2.4").unwrap());
+    assert!(SemverVersion::new(">1.2.3").unwrap() < SemverVersion::new(">1.3.2").unwrap());
+    assert!(SemverVersion::new(">1.2.3").unwrap() < SemverVersion::new(">2.1.2").unwrap());
+    assert!(SemverVersion::new(">1.2").unwrap() < SemverVersion::new(">1.3").unwrap());
+    assert!(SemverVersion::new(">1.2").unwrap() < SemverVersion::new(">2.1").unwrap());
+    assert!(SemverVersion::new(">10").unwrap() < SemverVersion::new(">200").unwrap());
+    assert_eq!(
+        SemverVersion::new(">1.2.3")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1.2").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new(">1.2.3")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new(">1.2")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new(">1.2.4")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1.2.3").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert!(SemverVersion::new(">1.3.2").unwrap() > SemverVersion::new(">1.2.3").unwrap());
+    assert!(SemverVersion::new(">2.1.2").unwrap() > SemverVersion::new(">1.2.3").unwrap());
+    assert!(SemverVersion::new(">1.3").unwrap() > SemverVersion::new(">1.2").unwrap());
+    assert!(SemverVersion::new(">2.1").unwrap() > SemverVersion::new(">1.2").unwrap());
+    assert!(SemverVersion::new(">200").unwrap() > SemverVersion::new(">10").unwrap());
+    assert_eq!(
+        SemverVersion::new(">1.2")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1.2.3").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        SemverVersion::new(">1")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1.2.3").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        SemverVersion::new(">1")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1.2").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        SemverVersion::new("=1.2.2")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">1.2.2").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new("=10")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">9.0.9").unwrap()),
+        None
+    );
+}
+
+#[test]
 fn semver_version_applies_partial_equal_as_expected() {
     // assert
     assert_eq!(
@@ -293,7 +363,7 @@ fn semver_version_catches_invalid_semver_strings() {
         String::from("unexpected character '.' while parsing major version number")
     );
     assert_eq!(
-        SemverVersion::new(">2.1.3").unwrap_err(),
+        SemverVersion::new(">=2.1.3").unwrap_err(),
         String::from("Range version requirement comparison is not yet implemented")
     );
 }


### PR DESCRIPTION
# Description

Add support for "greater" semver requirements (`>1.2.3`) in cargo dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] cargo test run with all tests passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
