### PR TITLE
fix: 💫 add greater than equal semver requirement support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opt-level = 3
 [dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.95"
-clap = { version = "4.5.27", features = ["derive"] }
+clap = { version = "4.5.28", features = ["derive"] }
 clap-verbosity-flag = "3.0.2"
 config = "0.15.7"
 env_logger = "0.11.6"
@@ -28,7 +28,7 @@ git2 = "0.20.0"
 log = "0.4.25"
 semver = "1.0.25"
 serde = { version = "1.0.217", features = ["derive"] }
-toml = "0.8.19"
+toml = "0.8.20"
 
 [dev-dependencies]
 assert_fs = "1.1.2"

--- a/src/domain/semver/tests.rs
+++ b/src/domain/semver/tests.rs
@@ -261,6 +261,76 @@ fn semver_version_applies_partial_order_as_expected_for_greater_requirements() {
 }
 
 #[test]
+fn semver_version_applies_partial_order_as_expected_for_greater_or_equal_requirements() {
+    // assert
+    assert!(SemverVersion::new(">=1.2.3").unwrap() < SemverVersion::new(">=1.2.4").unwrap());
+    assert!(SemverVersion::new(">=1.2.3").unwrap() < SemverVersion::new(">=1.3.2").unwrap());
+    assert!(SemverVersion::new(">=1.2.3").unwrap() < SemverVersion::new(">=2.1.2").unwrap());
+    assert!(SemverVersion::new(">=1.2").unwrap() < SemverVersion::new(">=1.3").unwrap());
+    assert!(SemverVersion::new(">=1.2").unwrap() < SemverVersion::new(">=2.1").unwrap());
+    assert!(SemverVersion::new(">=10").unwrap() < SemverVersion::new(">=200").unwrap());
+    assert_eq!(
+        SemverVersion::new(">=1.2.3")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1.2").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        SemverVersion::new(">=1.2.3")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        SemverVersion::new(">=1.2")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        SemverVersion::new(">=1.2.4")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1.2.3").unwrap()),
+        Some(Ordering::Greater)
+    );
+    assert!(SemverVersion::new(">=1.3.2").unwrap() > SemverVersion::new(">=1.2.3").unwrap());
+    assert!(SemverVersion::new(">=2.1.2").unwrap() > SemverVersion::new(">=1.2.3").unwrap());
+    assert!(SemverVersion::new(">=1.3").unwrap() > SemverVersion::new(">=1.2").unwrap());
+    assert!(SemverVersion::new(">=2.1").unwrap() > SemverVersion::new(">=1.2").unwrap());
+    assert!(SemverVersion::new(">=200").unwrap() > SemverVersion::new(">=10").unwrap());
+    assert_eq!(
+        SemverVersion::new(">=1.2")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1.2.3").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new(">=1")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1.2.3").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new(">=1")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1.2").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new("=1.2.2")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=1.2.2").unwrap()),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        SemverVersion::new("=10")
+            .unwrap()
+            .partial_cmp(&SemverVersion::new(">=9.0.9").unwrap()),
+        None
+    );
+}
+
+#[test]
 fn semver_version_applies_partial_equal_as_expected() {
     // assert
     assert_eq!(
@@ -363,7 +433,11 @@ fn semver_version_catches_invalid_semver_strings() {
         String::from("unexpected character '.' while parsing major version number")
     );
     assert_eq!(
-        SemverVersion::new(">=2.1.3").unwrap_err(),
+        SemverVersion::new("<7.8.9").unwrap_err(),
+        String::from("Range version requirement comparison is not yet implemented")
+    );
+    assert_eq!(
+        SemverVersion::new("<=2.1.3").unwrap_err(),
         String::from("Range version requirement comparison is not yet implemented")
     );
 }


### PR DESCRIPTION
# Description

Add greater than, or equal semver requirement support; and
bump dependencies:

🔧 bump clap from 4.5.27 to 4.5.28
📦 bump toml from 0.8.19 to 0.8.20

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Dependency update

# How Has This Been Tested?

- [x] cargo test run with all tests passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
