### PR TITLE
fix: 💫 add multiple version requirement parsing

### DIFF
--- a/src/domain/semver/mod.rs
+++ b/src/domain/semver/mod.rs
@@ -61,30 +61,7 @@ impl fmt::Display for Version {
 
 impl PartialOrd for Version {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if Self::error_if_comparator_operator_not_supported(&self.req).is_err() {
-            return None;
-        }
-        // Wildcard and multiple version requirements not yet implemented - `new()` should not yet
-        // let them be created
-        debug_assert!(self.req.comparators.len() == 1 && other.req.comparators.len() == 1);
-
-        let range = self.range();
-        let other_range = other.range();
-        if range == other_range {
-            Some(Ordering::Equal)
-        } else if range.end <= other_range.start
-            || (range.start < other_range.start && range.end == other_range.end)
-            || (range.start == other_range.start && range.end < other_range.end)
-        {
-            Some(Ordering::Less)
-        } else if range.start >= other_range.end
-            || (range.start > other_range.start && range.end == other_range.end)
-            || (range.start == other_range.start && range.end > other_range.end)
-        {
-            Some(Ordering::Greater)
-        } else {
-            None
-        }
+        Version::range_compare(&self.comparator_ranges(), &other.comparator_ranges())
     }
 }
 
@@ -100,9 +77,27 @@ impl Version {
     pub fn new(version_number: &str) -> Result<Self, String> {
         let req = VersionReq::parse(version_number).map_err(|error| format!("{error}"))?;
 
-        let () = Self::error_if_comparator_operator_not_supported(&req)?;
+        // let () = Self::error_if_comparator_operator_not_supported(&req)?;
 
         Ok(Self { req })
+    }
+
+    fn range_compare(a: &Range<semver::Version>, b: &Range<semver::Version>) -> Option<Ordering> {
+        if a == b {
+            Some(Ordering::Equal)
+        } else if a.end <= b.start
+            || (a.start < b.start && a.end == b.end)
+            || (a.start == b.start && a.end < b.end)
+        {
+            Some(Ordering::Less)
+        } else if a.start >= b.end
+            || (a.start > b.start && a.end == b.end)
+            || (a.start == b.start && a.end > b.end)
+        {
+            Some(Ordering::Greater)
+        } else {
+            None
+        }
     }
 
     fn version_with_bumped_major(major: u64) -> semver::Version {
@@ -311,7 +306,7 @@ impl Version {
                 // <I.J.K
                 Range {
                     start,
-                    end: Self::version_with_bumped_patch(major, minor_version, patch_version),
+                    end: semver::Version::new(major, minor_version, patch_version),
                 }
             } else {
                 // <I.J
@@ -404,30 +399,60 @@ impl Version {
         }
     }
 
-    fn range(&self) -> Range<semver::Version> {
-        let first_comparator = self.req.comparators.first().unwrap();
+    /// Returns a vector containing the ranges for each comparator.  Collapses all ranges into a
+    /// single one if possible.  If collapsing to a single range is not possible, no attempt is
+    /// made to collapse any pairs of elements, which could feasibly be collapsed.  Result is
+    /// sorted by increasing range starts.
+    fn comparator_ranges(&self) -> Range<semver::Version> {
+        debug_assert!(!self.req.comparators.is_empty());
 
-        let Comparator {
-            op,
-            major,
-            minor,
-            patch,
-            ..
-        } = first_comparator;
-        match op {
-            Op::Caret => Self::caret_range(*major, *minor, *patch),
-            Op::Exact => Self::exact_range(*major, *minor, *patch),
-            Op::Greater => Self::greater_range(*major, *minor, *patch),
-            Op::GreaterEq => Self::greater_or_equal_range(*major, *minor, *patch),
-            Op::Less => Self::less_range(*major, *minor, *patch),
-            Op::LessEq => Self::less_or_equal_range(*major, *minor, *patch),
-            Op::Tilde => Self::tilde_range(*major, *minor, *patch),
-            Op::Wildcard => Self::wildcard_range(*major, *minor, *patch),
-            _ => unimplemented!(
-                "Ranges only implemented for caret, exact, greater than, greater than or equal, \
-                    less than, less than or equal, tilde and wildcard requirements."
-            ),
+        let mut start = semver::Version::new(0, 0, 0);
+        let mut end = semver::Version::new(u64::MAX, u64::MAX, u64::MAX);
+        for comparator in &self.req.comparators {
+            let Comparator {
+                op,
+                major,
+                minor,
+                patch,
+                ..
+            } = comparator;
+            let range = match op {
+                Op::Exact => Self::exact_range(*major, *minor, *patch),
+                Op::Greater => Self::greater_range(*major, *minor, *patch),
+                Op::GreaterEq => Self::greater_or_equal_range(*major, *minor, *patch),
+                Op::Less => Self::less_range(*major, *minor, *patch),
+                Op::LessEq => Self::less_or_equal_range(*major, *minor, *patch),
+                Op::Tilde => Self::tilde_range(*major, *minor, *patch),
+                Op::Caret => Self::caret_range(*major, *minor, *patch),
+                Op::Wildcard => Self::wildcard_range(*major, *minor, *patch),
+                _ => unimplemented!(),
+            };
+
+            match op {
+                Op::Exact | Op::Tilde | Op::Caret | Op::Wildcard | Op::Greater | Op::GreaterEq => {
+                    if range.start > start {
+                        start = range.start;
+                    }
+                }
+                _ => {}
+            }
+            match op {
+                Op::Exact | Op::Tilde | Op::Caret | Op::Wildcard | Op::Less | Op::LessEq => {
+                    if range.end < end {
+                        end = range.end;
+                    }
+                }
+                _ => {}
+            }
         }
+
+        if end < start {
+            log::error!(
+                "Unexpected invalid range requirement: {:?}",
+                self.req.comparators,
+            );
+        }
+        Range { start, end }
     }
 
     pub fn change_type(&self, other: &Self) -> Change {
@@ -474,28 +499,6 @@ impl Version {
         }
 
         Change::Unknown
-    }
-
-    fn error_if_comparator_operator_not_supported(req: &VersionReq) -> Result<(), String> {
-        if req.comparators.len() != 1 {
-            return Err(String::from(
-                "Multiple version requirement comparison is not yet implemented",
-            ));
-        }
-        let Comparator { op, .. } = req.comparators.first().expect("Index should be valid");
-        match op {
-            Op::Caret
-            | Op::Exact
-            | Op::Greater
-            | Op::GreaterEq
-            | Op::Less
-            | Op::LessEq
-            | Op::Tilde
-            | Op::Wildcard => Ok(()),
-            _ => Err(String::from(
-                "Unexpected version requirement. Requirement type is not yet implemented",
-            )),
-        }
     }
 
     fn fmt_comparator_version(


### PR DESCRIPTION
# Description

Add support for multiple crate range requirements (e.g. `>= 1.2, <1.5`)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] cargo test run with all tests passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
