### PR TITLE
fix: 💫 add support for muliple aliased crate versions

### DIFF
--- a/src/domain/cargo_toml/snapshots/rust_crate_diffs__domain__cargo_toml__tests__new_from_buffer_creates_expected_config.snap
+++ b/src/domain/cargo_toml/snapshots/rust_crate_diffs__domain__cargo_toml__tests__new_from_buffer_creates_expected_config.snap
@@ -1,6 +1,5 @@
 ---
 source: src/domain/cargo_toml/tests.rs
 expression: "format!(\"{outcome:?}\")"
-snapshot_kind: text
 ---
-File { dependencies: {"ahash": Simple("0.8.11"), "clap": Detailed(DetailedCargoDependency { version: "4.5.23" }), "clap-verbosity-flag": Simple("3.0.1"), "config": Simple("0.14.1"), "env_logger": Simple("0.11.5"), "git2": Simple("0.19.0"), "log": Simple("0.4.22"), "serde": Detailed(DetailedCargoDependency { version: "1.0.215" }), "sqlx": Detailed(DetailedCargoDependency { version: "0.8.2" })}, build_dependencies: None, dev_dependencies: Some({"assert_fs": Simple("1.1.2"), "trycmd": Simple("0.15.8")}) }
+File { dependencies: {"ahash": Simple("0.8.11"), "clap": Detailed(DetailedCargoDependency { version: "4.5.23", package: None }), "clap-verbosity-flag": Simple("3.0.1"), "config": Simple("0.14.1"), "env_logger": Simple("0.11.5"), "git2": Simple("0.19.0"), "log": Simple("0.4.22"), "serde": Detailed(DetailedCargoDependency { version: "1.0.215", package: None }), "sqlx": Detailed(DetailedCargoDependency { version: "0.8.2", package: None })}, build_dependencies: None, dev_dependencies: Some({"assert_fs": Simple("1.1.2"), "trycmd": Simple("0.15.8")}) }

--- a/src/domain/cargo_toml/snapshots/rust_crate_diffs__domain__cargo_toml__tests__new_successfully_parses_valid_cargo_toml_dependencies.snap
+++ b/src/domain/cargo_toml/snapshots/rust_crate_diffs__domain__cargo_toml__tests__new_successfully_parses_valid_cargo_toml_dependencies.snap
@@ -1,12 +1,12 @@
 ---
 source: src/domain/cargo_toml/tests.rs
 expression: dependencies
-snapshot_kind: text
 ---
 {
   "ahash": "0.8.11",
   "clap": {
-    "version": "4.5.23"
+    "version": "4.5.23",
+    "package": null
   },
   "clap-verbosity-flag": "3.0.1",
   "config": "0.14.1",
@@ -14,9 +14,11 @@ snapshot_kind: text
   "git2": "0.19.0",
   "log": "0.4.22",
   "serde": {
-    "version": "1.0.215"
+    "version": "1.0.215",
+    "package": null
   },
   "sqlx": {
-    "version": "0.8.2"
+    "version": "0.8.2",
+    "package": null
   }
 }


### PR DESCRIPTION
# Description

Add support for multiple aliased versions of a crate. For example you might
add two versions of a crate:

```toml
[dependencies]
getrandom = { version = "0.3.2", features = ["wasm_js"] }
getrandom2 = { package = "getrandom", version = "0.2.15", features = ["js"] }
```

This might be to ensure dependencies using different versions of that crates use the preferred feature set.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] cargo test run with all tests passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
